### PR TITLE
feature/custom-error-helper

### DIFF
--- a/lib/src/presentation/views/example_screen.dart
+++ b/lib/src/presentation/views/example_screen.dart
@@ -6,9 +6,11 @@ import 'package:image_picker/image_picker.dart';
 import 'package:loomi_flutter_boilerplate/src/presentation/widgets/custom_button.dart';
 import 'package:loomi_flutter_boilerplate/src/presentation/widgets/search_bar_component.dart';
 import 'package:loomi_flutter_boilerplate/src/utils/custom_colors.dart';
+import 'package:loomi_flutter_boilerplate/src/utils/helpers/custom_error_helper.dart';
 import 'package:loomi_flutter_boilerplate/src/utils/helpers/image_picker_helper.dart';
 import 'package:loomi_flutter_boilerplate/src/utils/helpers/scroll_listener_helper.dart';
 import 'package:loomi_flutter_boilerplate/src/utils/helpers/select_pictures_sheet_helper.dart';
+import 'package:loomi_flutter_boilerplate/src/utils/helpers/show_confirmation_dialog_helper.dart';
 
 import '../stores/example_store.dart';
 
@@ -86,6 +88,32 @@ class _ExampleScreenState extends State<ExampleScreen> {
                           hintText: "Pesquisar",
                           onChanged: (value) {
                             log("O valor só chegou agora: $value");
+                          },
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: CustomButton(
+                          text: "showDialogHelper",
+                          expanded: true,
+                          onTap: () {
+                            showConfirmationDialogHelper(
+                              context: context,
+                              confirmButtonText: "Confirmar",
+                              title: "Aqui você insere o título",
+                              body:
+                                  "E aqui o contéudo todo e aqui o contéudo todo e aqui o contéudo todo e aqui o contéudo todo e aqui o contéudo todo",
+                            );
+                          },
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: CustomButton(
+                          text: "customErrorHelper",
+                          expanded: true,
+                          onTap: () {
+                            customErrorHelper(context, e: Exception("erro"));
                           },
                         ),
                       ),

--- a/lib/src/presentation/widgets/custom_button.dart
+++ b/lib/src/presentation/widgets/custom_button.dart
@@ -1,36 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:loomi_flutter_boilerplate/src/utils/custom_colors.dart';
+import 'package:loomi_flutter_boilerplate/src/utils/fonts.dart';
 
 class CustomButton extends StatelessWidget {
   const CustomButton({
     Key? key,
-    required this.backgroundColor,
+    this.backgroundColor,
     this.margin,
     this.padding,
-    required this.onTap,
     this.borderColor,
     this.borderThickness,
     this.expanded = false,
     this.borderRadius,
-    required this.text,
     this.textStyle,
-    required this.textColor,
+    this.textColor,
     this.leading,
     this.trailing,
+    required this.text,
+    required this.onTap,
   }) : super(key: key);
 
-  final Color backgroundColor;
+  final Color? backgroundColor;
   final String text;
   final TextStyle? textStyle;
-  final Color textColor;
+  final Color? textColor;
   final Widget? leading;
   final Widget? trailing;
   final EdgeInsets? margin;
   final EdgeInsets? padding;
-  final Function() onTap;
   final Color? borderColor;
   final double? borderThickness;
   final bool expanded;
   final double? borderRadius;
+  final Function() onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -38,13 +40,14 @@ class CustomButton extends StatelessWidget {
       onTap: onTap,
       child: Container(
         decoration: BoxDecoration(
-          color: backgroundColor,
-          borderRadius: BorderRadius.circular(borderRadius ?? 5),
+          color: backgroundColor ?? CustomColors.black,
+          borderRadius: BorderRadius.circular(borderRadius ?? 32),
           border: Border.all(
-              color: borderColor ?? Colors.transparent,
-              width: borderThickness ?? 0.0),
+            color: borderColor ?? Colors.transparent,
+            width: borderThickness ?? 0.0,
+          ),
         ),
-        padding: padding ?? const EdgeInsets.all(10),
+        padding: padding ?? const EdgeInsets.symmetric(vertical: 25),
         margin: margin ?? EdgeInsets.zero,
         child: Row(
           mainAxisSize: expanded ? MainAxisSize.max : MainAxisSize.min,
@@ -55,7 +58,10 @@ class CustomButton extends StatelessWidget {
               child: Text(
                 text,
                 textAlign: TextAlign.center,
-                style: textStyle ?? TextStyle(color: textColor),
+                style: textStyle ??
+                    Fonts.headline5.copyWith(
+                      color: textColor ?? CustomColors.white,
+                    ),
               ),
             ),
             if (trailing != null) trailing!

--- a/lib/src/utils/helpers/custom_error_helper.dart
+++ b/lib/src/utils/helpers/custom_error_helper.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
+import 'package:loomi_flutter_boilerplate/src/utils/helpers/show_confirmation_dialog_helper.dart';
+
+void customErrorHelper(
+  BuildContext context, {
+  required e,
+}) async {
+  if (e is DioError) {
+    if (e.response != null) {
+      showConfirmationDialogHelper(
+        body:
+            // FORMATO PARA PEGAR ERRO DIRETO DA RESPONSE DA API, VAI DEPENDER DO FORMATO QUE CADA BACKEND RETORNAR
+            e.response!.data['display_error'] ?? "Ocorreu um erro inesperado.",
+        confirmButtonText: 'OK',
+        context: context,
+        title: 'Erro',
+      );
+    } else {
+      showConfirmationDialogHelper(
+        body: "Ocorreu um erro inesperado.",
+        confirmButtonText: 'OK',
+        context: context,
+        title: 'Erro',
+      );
+    }
+  }
+
+  showConfirmationDialogHelper(
+    body: "Ocorreu um erro inesperado.",
+    confirmButtonText: 'OK',
+    context: context,
+    title: 'Erro',
+  );
+}

--- a/lib/src/utils/helpers/show_confirmation_dialog_helper.dart
+++ b/lib/src/utils/helpers/show_confirmation_dialog_helper.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:loomi_flutter_boilerplate/src/presentation/widgets/custom_button.dart';
-import '../../utils/custom_colors.dart';
-import '../../utils/fonts.dart';
-import 'custom_modal_bottom_sheet.dart';
+import '../custom_colors.dart';
+import '../fonts.dart';
+import '../../presentation/widgets/custom_modal_bottom_sheet.dart';
 
 void showConfirmationDialogHelper({
   required BuildContext context,
@@ -99,7 +99,7 @@ void showConfirmationDialogHelper({
               children: [
                 Expanded(
                   child: CustomButton(
-                    text: "Ok",
+                    text: confirmButtonText ?? "Ok",
                     backgroundColor: CustomColors.black,
                     textColor: CustomColors.white,
                     onTap: () {


### PR DESCRIPTION
**What I did:**
- Add a Custom Error Helper function
- Fix Custom Button style and requireds

** Why:**
- The customErrorHelper function exists to receive a context and a Exception object, constantly used on the catch of API actions on our stores. 

**How to test:**
1. **Run the following commands:**
+ flutter clean
+ flutter pub get

2. **How to get there**
+ Run the app

**What to test:**
+ Check if the showDialogHelper and customErrorHelper buttons shows a bottomSheet on the screen
+ Test the things that you think are worth testing, even the ones that are not in this description

**Expected results:**
+ The bottomSheetModals should open 


